### PR TITLE
Upgrade log4j dependency (CVE-2021-44228, CVE-2021-45046)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,3 +18,13 @@ dependencies {
 application {
     mainClass = 'sample.vulnerable.log4j.indirect.app.App'
 }
+
+// Force usage of log4j dependencies that are not vulnerable to CVE-2021-44228. #upgrade-log4j-gradle-cve-2021-44228
+configurations.all {
+  resolutionStrategy.eachDependency { details ->
+    if (details.target.group == 'org.apache.logging.log4j' && details.target.version < '2.17.0') {
+      details.useVersion '2.17.0'
+      details.because 'CVE-2021-44228'
+    }
+  }
+}


### PR DESCRIPTION
Upgrades log4j to a version not affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) nor [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046)

[_Created by Sourcegraph batch change `beyang/upgrade-log4j-v2.17-gradle`._](https://demo.sourcegraph.com/users/beyang/batch-changes/upgrade-log4j-v2.17-gradle)